### PR TITLE
using a different docker base image for web container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM maven:3.2-jdk-7-onbuild
+FROM maven:3.2-jdk-7
 MAINTAINER danmikita@gmail.com
 EXPOSE 8080
 COPY . /opt/conference_web

--- a/src/main/resources/liquibase/liquibase.properties
+++ b/src/main/resources/liquibase/liquibase.properties
@@ -1,4 +1,4 @@
 driver: org.postgresql.Driver
-url: jdbc:postgresql://172.17.0.2:5432/postgres
+url: jdbc:postgresql://postgres:5432/postgres
 username: postgres
 password: postgres


### PR DESCRIPTION
- changing the base image to non onbuild
- removed the ip address used for postgres container from liquibase.properties
