### PR TITLE
Feature/conference stubs 16

### DIFF
--- a/src/main/java/com/ioextendedgr/web/controller/ConferenceController.java
+++ b/src/main/java/com/ioextendedgr/web/controller/ConferenceController.java
@@ -1,0 +1,20 @@
+package com.ioextendedgr.web.controller;
+
+import java.util.List;
+
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.ioextendedgr.web.util.StubFactory;
+import com.ioextendedgr.web.viewDto.ConferenceView;
+
+@RestController
+public class ConferenceController {
+
+    @RequestMapping("/conference")
+    public List<ConferenceView> findAllConferences() {
+    	return StubFactory.createConferenceViews();
+    }
+
+	
+}

--- a/src/main/java/com/ioextendedgr/web/util/StubFactory.java
+++ b/src/main/java/com/ioextendedgr/web/util/StubFactory.java
@@ -1,0 +1,53 @@
+package com.ioextendedgr.web.util;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+import com.ioextendedgr.web.viewDto.ConferenceView;
+import com.ioextendedgr.web.viewDto.LocationView;
+
+public class StubFactory {
+
+	public static List<ConferenceView> createConferenceViews() {
+		int conferenceListSize = 10;
+		List<ConferenceView> conferenceList = new ArrayList<ConferenceView>();
+		
+		for (int i = 0; i < conferenceListSize; i++) {
+			conferenceList.add(toConferenceView(i));
+		}
+		
+		return conferenceList;
+		
+	}
+
+	private static ConferenceView toConferenceView(int index) {
+		
+		ConferenceView conferenceView = new ConferenceView();
+		conferenceView.setCreateDttm(new Date());
+		conferenceView.setEndDate(new Date());
+		conferenceView.setFullDesc(String.format("Conference: %d The complete full description in all of it's glory", index));
+		conferenceView.setId(Long.valueOf(index));
+		conferenceView.setLastUpdateDttm(new Date());
+		conferenceView.setLocationView(toLocationView(index));
+		conferenceView.setName(String.format("Conference %d", index));
+		conferenceView.setShortDesc(String.format("Conf %d short desc", index));
+		conferenceView.setStartDate(new Date());
+		
+		return conferenceView;
+	}
+
+	private static LocationView toLocationView(int index) {
+		LocationView dto = new LocationView();
+		
+		dto.setCreateDttm(new Date());
+		dto.setFullDesc(String.format("Full Description Location: %d", index));
+		dto.setId(Long.valueOf(index));
+		dto.setLastUpdateDttm(new Date());
+		dto.setName(String.format("Location %d", index));
+		dto.setParkingInfo(String.format("The parking information for Location: %d is the following....", index));
+		dto.setShortDesc(String.format("Location: %d", index));
+		
+		return dto;
+	}
+}

--- a/src/main/java/com/ioextendedgr/web/viewDto/ConferenceView.java
+++ b/src/main/java/com/ioextendedgr/web/viewDto/ConferenceView.java
@@ -1,0 +1,73 @@
+package com.ioextendedgr.web.viewDto;
+
+import java.util.Date;
+
+public class ConferenceView {
+	
+	private Long id;
+	private String name;
+	private String shortDesc;
+	private String fullDesc;
+	private Date startDate;
+	private Date endDate;
+	private Date createDttm;
+	private Date lastUpdateDttm;
+	private LocationView locationView;
+	
+	public Long getId() {
+		return id;
+	}
+	public void setId(Long id) {
+		this.id = id;
+	}
+	public String getName() {
+		return name;
+	}
+	public void setName(String name) {
+		this.name = name;
+	}
+	public String getShortDesc() {
+		return shortDesc;
+	}
+	public void setShortDesc(String shortDesc) {
+		this.shortDesc = shortDesc;
+	}
+	public String getFullDesc() {
+		return fullDesc;
+	}
+	public void setFullDesc(String fullDesc) {
+		this.fullDesc = fullDesc;
+	}
+	public Date getStartDate() {
+		return startDate;
+	}
+	public void setStartDate(Date startDate) {
+		this.startDate = startDate;
+	}
+	public Date getEndDate() {
+		return endDate;
+	}
+	public void setEndDate(Date endDate) {
+		this.endDate = endDate;
+	}
+	
+	public Date getCreateDttm() {
+		return createDttm;
+	}
+	public void setCreateDttm(Date createDttm) {
+		this.createDttm = createDttm;
+	}
+	public Date getLastUpdateDttm() {
+		return lastUpdateDttm;
+	}
+	public void setLastUpdateDttm(Date lastUpdateDttm) {
+		this.lastUpdateDttm = lastUpdateDttm;
+	}
+	public LocationView getLocationView() {
+		return locationView;
+	}
+	public void setLocationView(LocationView locationView) {
+		this.locationView = locationView;
+	}
+
+}

--- a/src/main/java/com/ioextendedgr/web/viewDto/LocationView.java
+++ b/src/main/java/com/ioextendedgr/web/viewDto/LocationView.java
@@ -1,0 +1,59 @@
+package com.ioextendedgr.web.viewDto;
+
+import java.util.Date;
+
+public class LocationView {
+
+	private Long id;
+	private String name;
+	private String shortDesc;
+	private String fullDesc;
+	private String parkingInfo;
+	private Date createDttm;
+	private Date lastUpdateDttm;
+	public Long getId() {
+		return id;
+	}
+	public void setId(Long id) {
+		this.id = id;
+	}
+	public String getName() {
+		return name;
+	}
+	public void setName(String name) {
+		this.name = name;
+	}
+	public String getShortDesc() {
+		return shortDesc;
+	}
+	public void setShortDesc(String shortDesc) {
+		this.shortDesc = shortDesc;
+	}
+	public String getFullDesc() {
+		return fullDesc;
+	}
+	public void setFullDesc(String fullDesc) {
+		this.fullDesc = fullDesc;
+	}
+	public String getParkingInfo() {
+		return parkingInfo;
+	}
+	public void setParkingInfo(String parkingInfo) {
+		this.parkingInfo = parkingInfo;
+	}
+	public Date getCreateDttm() {
+		return createDttm;
+	}
+	public void setCreateDttm(Date createDttm) {
+		this.createDttm = createDttm;
+	}
+	public Date getLastUpdateDttm() {
+		return lastUpdateDttm;
+	}
+	public void setLastUpdateDttm(Date lastUpdateDttm) {
+		this.lastUpdateDttm = lastUpdateDttm;
+	}
+	
+	
+
+}

--- a/src/main/java/hello/Application.java
+++ b/src/main/java/hello/Application.java
@@ -4,7 +4,7 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.context.annotation.ComponentScan;
 
-@ComponentScan
+@ComponentScan(basePackages = {"hello", "com.ioextendedgr.web"})
 @EnableAutoConfiguration
 public class Application {
 


### PR DESCRIPTION
This pull request fulfills #16 

Specifically, there is now an endpoint **/conference** that will retrieve a mock list of conference view objects with their associated location.

This can be tested by bringing up the application and hitting the **/conference** url.  This only does a GET.  POST, UPDATE and DELETE operations are not yet supported.
